### PR TITLE
Add Blacklist ability

### DIFF
--- a/app.rb
+++ b/app.rb
@@ -59,11 +59,11 @@ class Application
     end
 
     def build_recommendations_and_notify(page_information)
-      engine                    = RecommendationEngine.new(page_information)
-      lists_of_recommendations  = NUMBER_OF_RECOMMENDATIONS.times.map { engine.generate }
-      recommendations           = { date: page_information[:date], budget: engine.budget, recommendations: lists_of_recommendations }
+      engine                   = RecommendationEngine.new(page_information)
+      lists_of_recommendations = NUMBER_OF_RECOMMENDATIONS.times.map { engine.generate }
+      recommendations          = { date: page_information[:date], budget: engine.budget, recommendations: lists_of_recommendations }
 
-      SlackAdapter.announce(recommendations, channel: '#accountability-stand')
+      SlackAdapter.announce(recommendations, channel: CHANNELS_TO_POST_TO)
     end
 
     def driver

--- a/lib/fooda_item.rb
+++ b/lib/fooda_item.rb
@@ -10,11 +10,11 @@ class FoodaItem
   end
 
   def self.from_element(element)
-    restaurant  = element['data-vendor_name']
-    category    = element['data-category']
-    name        = element.find_element(class: 'item__name').text
-    price       = element.find_element(class: 'item__price').text.gsub!('$', '').to_f
-    url         = element.find_element(tag_name: 'a').attribute('href')
+    restaurant = element['data-vendor_name']
+    category   = element['data-category']
+    name       = element.find_element(class: 'item__name').text
+    price      = element.find_element(class: 'item__price').text.gsub!('$', '').to_f
+    url        = element.find_element(tag_name: 'a').attribute('href')
 
     new(name:       name,
         price:      price,
@@ -25,5 +25,11 @@ class FoodaItem
 
   def under?(budget)
     price <= budget
+  end
+
+  def matches_blacklist?(blacklist)
+    blacklist.any? do |descriptor|
+      name.downcase.include?(descriptor)
+    end
   end
 end

--- a/lib/fooda_page.rb
+++ b/lib/fooda_page.rb
@@ -10,22 +10,22 @@ class FoodaPage
   end
 
   def parse
-    budget  = parse_budget
-    items   = parse_items
-    date    = parse_date
+    budget = parse_budget
+    items  = parse_items
+    date   = parse_date
 
     {
-      date: date,
+      date:   date,
       budget: budget,
-      items: items
+      items:  items
     }
   end
 
   private
 
   def parse_budget
-    div               = driver.find_element(class: 'marketing__item')
-    budget_as_string  = div.text.split(' ').first
+    div              = driver.find_element(class: 'marketing__item')
+    budget_as_string = div.text.split(' ').first
 
     budget_as_string.gsub!('$', '').to_f
   end
@@ -33,7 +33,7 @@ class FoodaPage
   def parse_items
     items = driver.find_elements(class: 'item')
 
-    items.map {|item| FoodaItem.from_element(item) }
+    items.map { |item| FoodaItem.from_element(item) }
   end
 
   def parse_date
@@ -41,7 +41,7 @@ class FoodaPage
     # it
     # text = driver.find_element(class: 'secondary-bar__label').text
     # text.gsub('delivery ', '')
-    js = "return document.getElementsByClassName('secondary-bar__label')[0].innerHTML"
+    js   = "return document.getElementsByClassName('secondary-bar__label')[0].innerHTML"
     text = driver.execute_script(js)
     text.split(',').last
   end

--- a/lib/recommendation_engine.rb
+++ b/lib/recommendation_engine.rb
@@ -1,13 +1,15 @@
 # Builds a list of recommended items
 class RecommendationEngine
-  attr_reader :budget, :items, :local_tax
+  attr_reader :budget, :items, :local_tax, :blacklist
 
   DEFAULT_LOCAL_TAX = 0.11 # This is about right for Crook county
+  DEFAULT_BLACKLIST = %w(tortilla sauce extra).freeze
 
-  def initialize(parsed_page, local_tax = DEFAULT_LOCAL_TAX)
-    @budget     = parsed_page[:budget]
-    @items      = parsed_page[:items]
-    @local_tax  = local_tax
+  def initialize(parsed_page, blacklist = DEFAULT_BLACKLIST, local_tax = DEFAULT_LOCAL_TAX)
+    @budget    = parsed_page[:budget]
+    @items     = parsed_page[:items]
+    @local_tax = local_tax
+    @blacklist = blacklist
   end
 
   def generate
@@ -15,7 +17,7 @@ class RecommendationEngine
 
     [].tap do |selected_items|
       while budget_remaining != 0 do
-        available_items = items.select {|item| item.under?(budget_remaining) }
+        available_items = items.select { |item| item.under?(budget_remaining) && !item.matches_blacklist?(blacklist) }
 
         if available_items.any?
           item = available_items.sample

--- a/lib/slack_adapter.rb
+++ b/lib/slack_adapter.rb
@@ -3,11 +3,11 @@ require 'slack'
 
 
 class SlackAdapter
-  TOKEN = ENV.fetch('SLACK_TOKEN')
+  TOKEN                = ENV.fetch('SLACK_TOKEN')
   AWESOME_DESCRIPTIONS = ['piping hot', 'b r e a t h t a k i n g', 'mouth-watering', 'flippin\' fresh']
 
   class << self
-    def announce(recommendations, channel: )
+    def announce(recommendations, channel:)
       file_content = build_recommendation_file(recommendations)
 
       client.files_upload(
@@ -34,7 +34,7 @@ class SlackAdapter
     private
 
     def client
-      client = Slack::Web::Client.new(token: TOKEN)
+      Slack::Web::Client.new(token: TOKEN)
     end
   end
 end


### PR DESCRIPTION
# Problem

The recommendation engine does not exclude things like "extra sauce" that are ordinarily pretty useless.

# Proposal

Rather than keep them around but reduce the weight of them being able to be selected, we blacklist them.